### PR TITLE
Move git hub workflow back to main project

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
 
+      # CD Into Client Folder
+      - name: Move into client folder
+        run: cd client
+
       # Setup Node
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
Move git hub workflow back to main project and add a step to move into client folder before executing